### PR TITLE
[MOB-415] Add ability to reset Keychain credentials during first-launch

### DIFF
--- a/packages/mobile-wallet/src/state/sagas/appInit.js
+++ b/packages/mobile-wallet/src/state/sagas/appInit.js
@@ -1,9 +1,41 @@
 import * as Keychain from 'react-native-keychain';
+import { AsyncStorage } from 'react-native';
 import { call } from 'redux-saga/effects';
+import { isNil } from 'lodash';
 
 import { navigators } from 'state/navigator';
 
+function* isHasLaunched() {
+  const HAS_LAUNCHED = 'hasLaunched';
+
+  const hasLaunched = yield call(AsyncStorage.getItem, HAS_LAUNCHED);
+
+  if (isNil(hasLaunched)) {
+    yield call(AsyncStorage.setItem, HAS_LAUNCHED, 'true');
+
+    return false;
+  }
+
+  return true;
+}
+
+function* resetKeychainCredentials() {
+  yield call(Keychain.resetGenericPassword, {
+    service: 'pin',
+  });
+
+  yield call(Keychain.resetGenericPassword, {
+    service: 'mnemonic',
+  });
+}
+
 export default function* appInit() {
+  const hasLaunched = yield call(isHasLaunched);
+
+  if (!hasLaunched) {
+    yield call(resetKeychainCredentials);
+  }
+
   const pinStore = yield call(Keychain.getGenericPassword, {
     service: 'pin',
   });


### PR DESCRIPTION
Added ability to reset Keychain credentials during first launch, depending on specific flag stored in `AsyncStorage`, which will not persist after app will be deleted and reinstalled